### PR TITLE
feat(landing): add social links to footer with live GitHub star count

### DIFF
--- a/apps/web/src/features/landing/__tests__/LandingPage.component.test.tsx
+++ b/apps/web/src/features/landing/__tests__/LandingPage.component.test.tsx
@@ -8,6 +8,21 @@ vi.mock("next-themes", () => ({
 	useTheme: useThemeMock,
 }));
 
+// The tests call LandingPage() directly as a plain function (no React renderer),
+// so useState/useEffect have no dispatcher. Stub them as no-ops so useGitHubStars
+// returns null (star count hidden) without throwing.
+vi.mock("react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react")>();
+	return {
+		...actual,
+		useState: <T,>(init: T | (() => T)) => {
+			const value = typeof init === "function" ? (init as () => T)() : init;
+			return [value, vi.fn()] as [T, ReturnType<typeof vi.fn>];
+		},
+		useEffect: vi.fn(),
+	};
+});
+
 type ElementLike = {
 	type?: unknown;
 	props?: {

--- a/apps/web/src/features/landing/components/LandingPage.tsx
+++ b/apps/web/src/features/landing/components/LandingPage.tsx
@@ -1,6 +1,23 @@
 import { Check, CheckCircle2, Copy, Moon, Search, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+
+const GITHUB_STAR_THRESHOLD = 10;
+
+function useGitHubStars(repo: string): number | null {
+	const [stars, setStars] = useState<number | null>(null);
+	useEffect(() => {
+		fetch(`https://api.github.com/repos/${repo}`)
+			.then((r) => r.json())
+			.then((data) => {
+				if (typeof data.stargazers_count === "number") {
+					setStars(data.stargazers_count);
+				}
+			})
+			.catch(() => {});
+	}, [repo]);
+	return stars;
+}
 import { Button } from "../../../shared/ui/Button";
 import { LoopwireSpinner } from "../../../shared/ui/LoopwireSpinner";
 import { LoopwireLogo } from "./LoopwireLogo";
@@ -46,6 +63,7 @@ export function LandingPage({
 	arrivedViaTokenLink = false,
 }: LandingPageProps) {
 	const { resolvedTheme, setTheme } = useTheme();
+	const githubStars = useGitHubStars("loopwire-dev/loopwire");
 	const selectedStep = discoveryEnabled || arrivedViaTokenLink ? 2 : 1;
 	const setupSelected = selectedStep === 1;
 	const scanSelected = selectedStep === 2;
@@ -223,14 +241,60 @@ export function LandingPage({
 			</main>
 
 			{/* Footer */}
-			<footer className="text-center text-sm text-muted pb-6 pt-2">
+			<footer className="text-center text-sm text-muted pb-6 pt-2 flex flex-col items-center gap-3">
+				<div className="flex items-center gap-3">
+					<a
+						href="https://github.com/loopwire-dev/loopwire"
+						target="_blank"
+						rel="noopener noreferrer"
+						aria-label="Star Loopwire on GitHub"
+						className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-xs font-medium text-muted hover:text-foreground hover:border-foreground/30 transition-colors"
+					>
+						<svg
+							aria-hidden="true"
+							width="13"
+							height="13"
+							viewBox="0 0 24 24"
+							fill="currentColor"
+						>
+							<path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.929.43.372.823 1.102.823 2.222 0 1.606-.015 2.896-.015 3.286 0 .322.216.694.825.576C20.565 21.795 24 17.295 24 12c0-6.63-5.37-12-12-12z" />
+						</svg>
+						<svg
+							aria-hidden="true"
+							width="11"
+							height="11"
+							viewBox="0 0 24 24"
+							fill="currentColor"
+						>
+							<path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+						</svg>
+						<span>Star</span>
+						{githubStars !== null && githubStars > GITHUB_STAR_THRESHOLD && (
+							<span className="text-xs tabular-nums">
+								{githubStars.toLocaleString()}
+							</span>
+						)}
+					</a>
+					<a
+						href="https://x.com/loopwiredev"
+						target="_blank"
+						rel="noopener noreferrer"
+						aria-label="Follow @loopwiredev on X"
+						className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1 text-xs font-medium text-muted hover:text-foreground hover:border-foreground/30 transition-colors"
+					>
+						<svg
+							aria-hidden="true"
+							width="11"
+							height="11"
+							viewBox="0 0 24 24"
+							fill="currentColor"
+						>
+							<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.253 5.622 5.911-5.622zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+						</svg>
+						<span>@loopwiredev</span>
+					</a>
+				</div>
 				<p>Made by 🤖 and 🧑 with 🦾</p>
-				<a
-					href="mailto:info@loopwire.dev"
-					className="text-muted hover:text-foreground transition-colors"
-				>
-					info@loopwire.dev
-				</a>
 			</footer>
 		</div>
 	);


### PR DESCRIPTION
## Summary

Adds a social row to the landing page footer with two pill-shaped links:

- **GitHub Star** — links to `github.com/loopwire-dev/loopwire`, fetches `stargazers_count` from the GitHub API on mount, and displays the count only when it exceeds 10 (configurable via `GITHUB_STAR_THRESHOLD`). Count is hidden if the API call fails or the threshold isn't met.
- **X follow** — links to `x.com/loopwiredev` with the `@loopwiredev` handle.

Also removes the `info@loopwire.dev` contact email from the footer.

## Linked Issue

N/A

## Testing

- Updated `LandingPage.component.test.tsx` to stub `useState`/`useEffect` from React, since the test suite calls the component as a plain function (no renderer). This keeps `githubStars` as `null` in tests (star count hidden), which is the correct behaviour.
- All existing tests pass; both landing page tests continue to exercise theme toggling and discovery state.

## Checklist

- [x] PR title is clear and scoped.
- [x] Tests were added/updated, or N/A is explained.
- [x] Documentation/changelog impact was considered.
- [x] Breaking changes are documented.