### PR TITLE
fix(daemon): stabilize macOS startup and agent runtime environment

### DIFF
--- a/apps/daemon/crates/lw-api/src/router.rs
+++ b/apps/daemon/crates/lw-api/src/router.rs
@@ -171,7 +171,15 @@ pub fn build_router(state: AppState) -> Router {
         .merge(protected_routes)
         .merge(ws_routes)
         .layer(cors)
-        .layer(TraceLayer::new_for_http())
+        .layer(TraceLayer::new_for_http().make_span_with(
+            |request: &axum::http::Request<axum::body::Body>| {
+                tracing::info_span!(
+                    "http_request",
+                    method = %request.method(),
+                    uri = %request.uri()
+                )
+            },
+        ))
         .with_state(state)
 }
 

--- a/apps/daemon/crates/lw-pty/src/session.rs
+++ b/apps/daemon/crates/lw-pty/src/session.rs
@@ -51,6 +51,13 @@ impl PtySession {
             cmd.env(key, value);
         }
 
+        // Remove parent-session markers that would cause agents to refuse to
+        // start (e.g. Claude Code detecting it is being launched inside an
+        // existing Claude Code session).
+        for key in &["CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT"] {
+            cmd.env_remove(key);
+        }
+
         let child = pair
             .slave
             .spawn_command(cmd)


### PR DESCRIPTION
## Summary
This PR fixes daemon startup/session issues on macOS and improves runtime robustness for agent launches.

## Changes
- Use `launchctl` for `loopwired start` on macOS when a Loopwire LaunchAgent is installed.
- Harden PID ownership checks in `loopwired` `start`/`status`/`stop`.
- Improve login-shell PATH and command resolution in `lw-agent` under noisy shell init output.
- Add HTTP trace span context (`method`, `uri`) in `lw-api` router.
- Remove parent-session Claude markers from PTY child env in `lw-pty`.

## Why
- Prevent terminal-tab instability seen in Warp/Ghostty when invoking daemon start.
- Avoid stale/foreign PID file conflicts.
- Make agent binary discovery resilient in launchd environments.

## Validation
- `cargo test -p loopwired -p lw-agent -p lw-api -p lw-pty`
- `cargo test -p lw-agent runners::tests::resolve_login_shell_path_is_nonempty_and_absolute -- --exact`
- `cargo test -p lw-agent runners::tests::resolve_command_path_real_binary -- --exact`
- `cargo test -p lw-api router::tests::is_private_network_origin_public_domain -- --exact`
- `cargo test -p lw-pty`
