### PR TITLE
fix(web): show agent launch spinner immediately on click

### DIFF
--- a/apps/web/src/features/agent/__tests__/InlineAgentPicker.component.test.tsx
+++ b/apps/web/src/features/agent/__tests__/InlineAgentPicker.component.test.tsx
@@ -80,7 +80,8 @@ describe("InlineAgentPicker", () => {
 		useStateMock
 			.mockReturnValueOnce(["", vi.fn()])
 			.mockReturnValueOnce([null, vi.fn()])
-			.mockReturnValueOnce([false, vi.fn()]);
+			.mockReturnValueOnce([false, vi.fn()])
+			.mockReturnValueOnce([null, vi.fn()]);
 		const state = {
 			availableAgents: [],
 			workspacePath: "/repo",
@@ -101,7 +102,8 @@ describe("InlineAgentPicker", () => {
 		useStateMock
 			.mockReturnValueOnce(["codex", vi.fn()])
 			.mockReturnValueOnce([null, setError])
-			.mockReturnValueOnce([false, vi.fn()]);
+			.mockReturnValueOnce([false, vi.fn()])
+			.mockReturnValueOnce([null, vi.fn()]);
 		const state = {
 			availableAgents: [
 				{

--- a/apps/web/src/features/agent/components/InlineAgentPicker.tsx
+++ b/apps/web/src/features/agent/components/InlineAgentPicker.tsx
@@ -1,6 +1,7 @@
 import { Bot, ExternalLink, Play } from "lucide-react";
 import { useState } from "react";
 import { useAppStore } from "../../../shared/stores/app-store";
+import { LoopwireSpinner } from "../../../shared/ui/LoopwireSpinner";
 import { useAgent } from "../hooks/useAgent";
 import { getAgentIcon } from "../lib/agentIcons";
 
@@ -16,11 +17,13 @@ export function InlineAgentPicker() {
 	const [selectedAgent, setSelectedAgent] = useState("");
 	const [error, setError] = useState<string | null>(null);
 	const [starting, setStarting] = useState(false);
+	const [startingAgent, setStartingAgent] = useState<string | null>(null);
 	const workspacePath = useAppStore((s) => s.workspacePath);
 
 	const handleStart = async (agentType: string) => {
 		if (!workspacePath || starting) return;
 		setError(null);
+		setStartingAgent(agentType);
 		setStarting(true);
 		try {
 			await startSession(agentType, workspacePath);
@@ -28,6 +31,7 @@ export function InlineAgentPicker() {
 			setError(err instanceof Error ? err.message : "Failed to start session");
 		} finally {
 			setStarting(false);
+			setStartingAgent(null);
 		}
 	};
 
@@ -118,11 +122,25 @@ export function InlineAgentPicker() {
 												<ExternalLink size={14} />
 											</span>
 										)}
-										{a.installed && selectedAgent === a.agent_type && (
+										{starting && startingAgent === a.agent_type && (
 											<span className="ml-auto text-accent" aria-hidden="true">
-												<Play size={14} fill="currentColor" />
+												<LoopwireSpinner
+													size={14}
+													decorative
+													className="opacity-90"
+												/>
 											</span>
 										)}
+										{a.installed &&
+											!starting &&
+											selectedAgent === a.agent_type && (
+												<span
+													className="ml-auto text-accent"
+													aria-hidden="true"
+												>
+													<Play size={14} fill="currentColor" />
+												</span>
+											)}
 									</button>
 								);
 							})}


### PR DESCRIPTION
## Summary

Show launch feedback immediately in the Inline Agent Picker by rendering a per-agent spinner as soon as the user clicks to start a session.

This removes the perceived dead time between click and visible loading state.

## Linked Issue

Closes #12

## Testing

- `bun run test -- src/features/agent/__tests__/InlineAgentPicker.component.test.tsx`
- `bun run typecheck`

## Checklist

- [x] PR title is clear and scoped.
- [x] Tests were added/updated, or N/A is explained.
- [x] Documentation/changelog impact was considered.
- [x] Breaking changes are documented.
