### PR TITLE
fix(web,daemon): seamless agent launch overlay and auto-cleanup on exit

### DIFF
--- a/apps/daemon/crates/lw-agent/src/manager/recorder.rs
+++ b/apps/daemon/crates/lw-agent/src/manager/recorder.rs
@@ -188,6 +188,8 @@ impl ActivityRecorder {
                                 {
                                     let mut w = handles.write().await;
                                     if let Some(handle) = w.get_mut(&session_id) {
+                                        handle.status = super::session::AgentStatus::Stopped;
+                                        handle.process_id = None;
                                         // If the session was still Restored when
                                         // the process exited, the resume attempt
                                         // failed.  Mark as unresumable so the

--- a/apps/daemon/moon.yml
+++ b/apps/daemon/moon.yml
@@ -22,7 +22,7 @@ tasks:
       runInCI: false
 
   dev:
-    script: 'cargo watch -x "run --bin loopwired -- start"'
+    script: 'cargo watch -x "run --bin loopwired -- run"'
     deps:
       - 'setup'
     preset: server

--- a/apps/web/src/features/agent/__tests__/useAgent.hook.test.ts
+++ b/apps/web/src/features/agent/__tests__/useAgent.hook.test.ts
@@ -26,33 +26,40 @@ vi.mock("../../../shared/lib/daemon/rest", () => ({
 	updateAgentSessionSettings: updateAgentSessionSettingsMock,
 }));
 
-const upsertWorkspaceSessionMock = vi.fn();
-const removeWorkspaceSessionMock = vi.fn();
-const attachWorkspaceSessionMock = vi.fn();
-const setActivePanelMock = vi.fn();
-const setWorkspaceMock = vi.fn();
-type MockAppState = {
-	upsertWorkspaceSession: typeof upsertWorkspaceSessionMock;
-	removeWorkspaceSession: typeof removeWorkspaceSessionMock;
-	attachWorkspaceSession: typeof attachWorkspaceSessionMock;
-	setActivePanel: typeof setActivePanelMock;
-	setWorkspace: typeof setWorkspaceMock;
-};
+const {
+	upsertWorkspaceSessionMock,
+	removeWorkspaceSessionMock,
+	attachWorkspaceSessionMock,
+	setActivePanelMock,
+	setWorkspaceMock,
+	setAgentLaunchOverlayMock,
+} = vi.hoisted(() => ({
+	upsertWorkspaceSessionMock: vi.fn(),
+	removeWorkspaceSessionMock: vi.fn(),
+	attachWorkspaceSessionMock: vi.fn(),
+	setActivePanelMock: vi.fn(),
+	setWorkspaceMock: vi.fn(),
+	setAgentLaunchOverlayMock: vi.fn(),
+}));
 
 vi.mock("../../../shared/stores/app-store", async () => {
 	const actual = await vi.importActual<
 		typeof import("../../../shared/stores/app-store")
 	>("../../../shared/stores/app-store");
+	const mockState = {
+		upsertWorkspaceSession: upsertWorkspaceSessionMock,
+		removeWorkspaceSession: removeWorkspaceSessionMock,
+		attachWorkspaceSession: attachWorkspaceSessionMock,
+		setActivePanel: setActivePanelMock,
+		setWorkspace: setWorkspaceMock,
+		setAgentLaunchOverlay: setAgentLaunchOverlayMock,
+	};
+	const useAppStore = (selector: (state: typeof mockState) => unknown) =>
+		selector(mockState);
+	useAppStore.getState = () => mockState;
 	return {
 		...actual,
-		useAppStore: (selector: (state: MockAppState) => unknown) =>
-			selector({
-				upsertWorkspaceSession: upsertWorkspaceSessionMock,
-				removeWorkspaceSession: removeWorkspaceSessionMock,
-				attachWorkspaceSession: attachWorkspaceSessionMock,
-				setActivePanel: setActivePanelMock,
-				setWorkspace: setWorkspaceMock,
-			}),
+		useAppStore,
 	};
 });
 

--- a/apps/web/src/features/agent/components/InlineAgentPicker.tsx
+++ b/apps/web/src/features/agent/components/InlineAgentPicker.tsx
@@ -1,7 +1,6 @@
 import { Bot, ExternalLink, Play } from "lucide-react";
 import { useState } from "react";
 import { useAppStore } from "../../../shared/stores/app-store";
-import { LoopwireSpinner } from "../../../shared/ui/LoopwireSpinner";
 import { useAgent } from "../hooks/useAgent";
 import { getAgentIcon } from "../lib/agentIcons";
 
@@ -17,13 +16,11 @@ export function InlineAgentPicker() {
 	const [selectedAgent, setSelectedAgent] = useState("");
 	const [error, setError] = useState<string | null>(null);
 	const [starting, setStarting] = useState(false);
-	const [startingAgent, setStartingAgent] = useState<string | null>(null);
 	const workspacePath = useAppStore((s) => s.workspacePath);
 
 	const handleStart = async (agentType: string) => {
 		if (!workspacePath || starting) return;
 		setError(null);
-		setStartingAgent(agentType);
 		setStarting(true);
 		try {
 			await startSession(agentType, workspacePath);
@@ -31,7 +28,6 @@ export function InlineAgentPicker() {
 			setError(err instanceof Error ? err.message : "Failed to start session");
 		} finally {
 			setStarting(false);
-			setStartingAgent(null);
 		}
 	};
 
@@ -120,15 +116,6 @@ export function InlineAgentPicker() {
 										{!a.installed && a.agent_type === "gemini" && (
 											<span className="ml-auto text-muted" aria-hidden="true">
 												<ExternalLink size={14} />
-											</span>
-										)}
-										{starting && startingAgent === a.agent_type && (
-											<span className="ml-auto text-accent" aria-hidden="true">
-												<LoopwireSpinner
-													size={14}
-													decorative
-													className="opacity-90"
-												/>
 											</span>
 										)}
 										{a.installed &&

--- a/apps/web/src/features/agent/hooks/useAgent.ts
+++ b/apps/web/src/features/agent/hooks/useAgent.ts
@@ -51,6 +51,7 @@ export function useAgent() {
 	const startSession = useCallback(
 		async (agentType: string, workspacePath: string) => {
 			setLoading(true);
+			useAppStore.getState().setAgentLaunchOverlay(true);
 			try {
 				const res = await startAgentSession(agentType, workspacePath);
 
@@ -70,6 +71,9 @@ export function useAgent() {
 				});
 				setWorkspace(workspacePath, res.workspace_id);
 				return res;
+			} catch (err) {
+				useAppStore.getState().setAgentLaunchOverlay(false);
+				throw err;
 			} finally {
 				setLoading(false);
 			}

--- a/apps/web/src/features/ide/__tests__/WorkspaceView.component.test.tsx
+++ b/apps/web/src/features/ide/__tests__/WorkspaceView.component.test.tsx
@@ -73,6 +73,15 @@ describe("WorkspaceView", () => {
 		useMemoMock.mockImplementation((factory: () => unknown) => factory());
 	});
 
+	/** Helper: extract the visible content panel from WorkspaceView's tree.
+	 *  The content wrapper now holds [overlay | false, content]. */
+	// biome-ignore lint/suspicious/noExplicitAny: test helper
+	function extractContent(tree: any) {
+		const children = tree.props.children[2].props.children;
+		// children is [agentLaunchOverlay element | false, content]
+		return Array.isArray(children) ? children[1] : children;
+	}
+
 	it("renders files panel by default", async () => {
 		const state = {
 			workspacePath: "/repo",
@@ -81,6 +90,7 @@ describe("WorkspaceView", () => {
 				key1: [],
 			},
 			activePanelByWorkspacePath: {},
+			agentLaunchOverlay: false,
 			setActivePanel: vi.fn(),
 		};
 		useAppStoreMock.mockImplementation(
@@ -90,7 +100,7 @@ describe("WorkspaceView", () => {
 
 		const { WorkspaceView } = await import("../components/WorkspaceView");
 		const tree = WorkspaceView();
-		const content = tree.props.children[2].props.children;
+		const content = extractContent(tree);
 
 		expect(content.type).toBe(FilesPanelViewMock);
 	});
@@ -105,6 +115,7 @@ describe("WorkspaceView", () => {
 			activePanelByWorkspacePath: {
 				key1: { kind: "panel", panel: "git" },
 			},
+			agentLaunchOverlay: false,
 			setActivePanel: vi.fn(),
 		};
 		useAppStoreMock.mockImplementation(
@@ -114,7 +125,7 @@ describe("WorkspaceView", () => {
 
 		const { WorkspaceView } = await import("../components/WorkspaceView");
 		const tree = WorkspaceView();
-		const content = tree.props.children[2].props.children;
+		const content = extractContent(tree);
 
 		expect(content.type).toBe(GitPanelViewMock);
 	});
@@ -131,6 +142,7 @@ describe("WorkspaceView", () => {
 			activePanelByWorkspacePath: {
 				key1: { kind: "agent", sessionId: "s1" },
 			},
+			agentLaunchOverlay: false,
 			setActivePanel: vi.fn(),
 		};
 		useAppStoreMock.mockImplementation(
@@ -140,7 +152,7 @@ describe("WorkspaceView", () => {
 
 		const { WorkspaceView } = await import("../components/WorkspaceView");
 		const tree = WorkspaceView();
-		const content = tree.props.children[2].props.children;
+		const content = extractContent(tree);
 
 		expect(content.type).toBe(TerminalMock);
 		expect(content.props.sessionId).toBe("s1");
@@ -156,6 +168,7 @@ describe("WorkspaceView", () => {
 			activePanelByWorkspacePath: {
 				key1: { kind: "agent", sessionId: "missing" },
 			},
+			agentLaunchOverlay: false,
 			setActivePanel: vi.fn(),
 		};
 		useAppStoreMock.mockImplementation(
@@ -165,7 +178,7 @@ describe("WorkspaceView", () => {
 
 		const { WorkspaceView } = await import("../components/WorkspaceView");
 		const tree = WorkspaceView();
-		const content = tree.props.children[2].props.children;
+		const content = extractContent(tree);
 
 		expect(content.type).toBe(FilesPanelViewMock);
 	});

--- a/apps/web/src/features/ide/components/WorkspaceView.tsx
+++ b/apps/web/src/features/ide/components/WorkspaceView.tsx
@@ -4,6 +4,7 @@ import {
 	useAppStore,
 	workspaceStoreKeyForSelection,
 } from "../../../shared/stores/app-store";
+import { LoopwireSpinner } from "../../../shared/ui/LoopwireSpinner";
 import { InlineAgentPicker } from "../../agent/components/InlineAgentPicker";
 import { Terminal } from "../../terminal/components/Terminal";
 import { FilesPanelView } from "./FilesPanelView";
@@ -13,6 +14,7 @@ import { WorkspaceSidebar } from "./WorkspaceSidebar";
 export function WorkspaceView() {
 	const workspacePath = useAppStore((s) => s.workspacePath);
 	const workspaceId = useAppStore((s) => s.workspaceId);
+	const agentLaunchOverlay = useAppStore((s) => s.agentLaunchOverlay);
 	const sessionsByWorkspacePath = useAppStore((s) => s.sessionsByWorkspacePath);
 	const activePanelByWorkspacePath = useAppStore(
 		(s) => s.activePanelByWorkspacePath,
@@ -102,7 +104,15 @@ export function WorkspaceView() {
 		<div className="h-full flex">
 			<WorkspaceSidebar sessions={sessions} activePanel={activePanel} />
 			<div className="w-px bg-border shrink-0" />
-			<div className="flex-1 min-w-0 overflow-hidden">{content}</div>
+			<div className="flex-1 min-w-0 overflow-hidden relative">
+				{agentLaunchOverlay && (
+					<div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-surface">
+						<LoopwireSpinner size={26} label="Loading terminal" />
+						<p className="text-xs text-muted">Getting things ready...</p>
+					</div>
+				)}
+				{content}
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/features/terminal/__tests__/terminalEventHandlers.test.ts
+++ b/apps/web/src/features/terminal/__tests__/terminalEventHandlers.test.ts
@@ -1,4 +1,28 @@
 import { describe, expect, it, vi } from "vitest";
+
+const {
+	removeSessionByIdMock,
+	setAgentLaunchOverlayMock,
+	stopAgentSessionMock,
+} = vi.hoisted(() => ({
+	removeSessionByIdMock: vi.fn(),
+	setAgentLaunchOverlayMock: vi.fn(),
+	stopAgentSessionMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../shared/stores/app-store", () => ({
+	useAppStore: Object.assign(() => {}, {
+		getState: () => ({
+			setAgentLaunchOverlay: setAgentLaunchOverlayMock,
+			removeSessionById: removeSessionByIdMock,
+		}),
+	}),
+}));
+
+vi.mock("../../../shared/lib/daemon/rest", () => ({
+	stopAgentSession: stopAgentSessionMock,
+}));
+
 import {
 	createTerminalChannelHandlers,
 	createTerminalWheelHandler,
@@ -124,7 +148,8 @@ describe("terminalEventHandlers channel handlers", () => {
 		);
 
 		handlers.onExit(9);
-		expect(setConnectionError).toHaveBeenCalledWith("Process exited (code 9).");
+		expect(removeSessionByIdMock).toHaveBeenCalledWith("s1");
+		expect(stopAgentSessionMock).toHaveBeenCalledWith("s1");
 
 		handlers.onError("boom");
 		expect(paging.reset).toHaveBeenCalledTimes(3);

--- a/apps/web/src/features/terminal/__tests__/useTerminal.hook.test.ts
+++ b/apps/web/src/features/terminal/__tests__/useTerminal.hook.test.ts
@@ -54,11 +54,11 @@ describe("useTerminal hook shell", () => {
 		);
 	});
 
-	it("sets loading from sessionId and returns false sendInput when no channel", async () => {
+	it("initialises loading as true and returns false sendInput when no channel", async () => {
 		const setLoading = vi.fn();
 		const setConnectionError = vi.fn();
 		useStateMock
-			.mockReturnValueOnce([false, setLoading])
+			.mockReturnValueOnce([true, setLoading])
 			.mockReturnValueOnce([null, setConnectionError])
 			.mockReturnValueOnce([null, vi.fn()]);
 
@@ -79,7 +79,7 @@ describe("useTerminal hook shell", () => {
 
 		const { useTerminal } = await import("../hooks/useTerminal");
 		const hook = useTerminal("sess-1", "dark");
-		expect(setLoading).toHaveBeenCalledWith(true);
+		expect(hook.isLoading).toBe(true);
 		expect(hook.sendInput("x")).toBe(false);
 	});
 
@@ -96,7 +96,7 @@ describe("useTerminal hook shell", () => {
 		};
 
 		useStateMock
-			.mockReturnValueOnce([false, setLoading])
+			.mockReturnValueOnce([true, setLoading])
 			.mockReturnValueOnce([null, setConnectionError])
 			.mockReturnValueOnce([terminal, vi.fn()]);
 

--- a/apps/web/src/features/terminal/components/Terminal.tsx
+++ b/apps/web/src/features/terminal/components/Terminal.tsx
@@ -31,6 +31,7 @@ export function Terminal({ sessionId }: TerminalProps) {
 		termTheme,
 		useCallback(() => setShowScrollback(true), []),
 	);
+	const agentLaunchOverlay = useAppStore((s) => s.agentLaunchOverlay);
 	const [isDragOver, setIsDragOver] = useState(false);
 	const containerRef = useRef<HTMLDivElement>(null);
 
@@ -122,8 +123,8 @@ export function Terminal({ sessionId }: TerminalProps) {
 			onDragLeave={handleDragLeave}
 			onDrop={handleDrop}
 		>
-			{isLoading && (
-				<div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-surface/70">
+			{isLoading && !agentLaunchOverlay && (
+				<div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-2 bg-surface">
 					<LoopwireSpinner size={26} label="Loading terminal" />
 					<p className="text-xs text-muted">Getting things ready...</p>
 				</div>

--- a/apps/web/src/features/terminal/hooks/useTerminal.ts
+++ b/apps/web/src/features/terminal/hooks/useTerminal.ts
@@ -60,14 +60,10 @@ export function useTerminal(
 
 	const token = useAppStore((s) => s.token);
 
-	const [isLoading, setIsLoading] = useState(false);
+	const [isLoading, setIsLoading] = useState(true);
 	const [connectionError, setConnectionError] = useState<string | null>(null);
 	const [terminal, setTerminal] = useState<XTerm | null>(null);
 	const gotFirstOutputRef = useRef(false);
-
-	useEffect(() => {
-		setIsLoading(Boolean(sessionId));
-	}, [sessionId]);
 
 	const sendInput = useCallback((data: string) => {
 		return channelRef.current?.sendInputUtf8(data) ?? false;

--- a/apps/web/src/features/workspace/__tests__/useGitStatus.test.ts
+++ b/apps/web/src/features/workspace/__tests__/useGitStatus.test.ts
@@ -8,6 +8,7 @@ const {
 	gitStatusMock,
 	isNotGitRepoErrorMock,
 	subscribeGitStatusMock,
+	resubscribeGitStatusMock,
 	unsubscribeGitStatusMock,
 	onGitStatusEventMock,
 	onDaemonWsReconnectMock,
@@ -19,6 +20,7 @@ const {
 	gitStatusMock: vi.fn(),
 	isNotGitRepoErrorMock: vi.fn(),
 	subscribeGitStatusMock: vi.fn(),
+	resubscribeGitStatusMock: vi.fn(),
 	unsubscribeGitStatusMock: vi.fn(),
 	onGitStatusEventMock: vi.fn(),
 	onDaemonWsReconnectMock: vi.fn(),
@@ -38,6 +40,7 @@ vi.mock("../../../shared/lib/daemon/rest", () => ({
 
 vi.mock("../../../shared/lib/daemon/ws", () => ({
 	subscribeGitStatus: subscribeGitStatusMock,
+	resubscribeGitStatus: resubscribeGitStatusMock,
 	unsubscribeGitStatus: unsubscribeGitStatusMock,
 	onGitStatusEvent: onGitStatusEventMock,
 	onDaemonWsReconnect: onDaemonWsReconnectMock,
@@ -70,6 +73,7 @@ describe("useGitStatus", () => {
 		gitStatusMock.mockReset();
 		isNotGitRepoErrorMock.mockReset();
 		subscribeGitStatusMock.mockReset();
+		resubscribeGitStatusMock.mockReset();
 		unsubscribeGitStatusMock.mockReset();
 		onGitStatusEventMock.mockReset();
 		onDaemonWsReconnectMock.mockReset();
@@ -123,7 +127,8 @@ describe("useGitStatus", () => {
 
 		if (!reconnectHandler) throw new Error("missing reconnect handler");
 		(reconnectHandler as () => void)();
-		expect(subscribeGitStatusMock).toHaveBeenCalledTimes(2);
+		expect(subscribeGitStatusMock).toHaveBeenCalledTimes(1);
+		expect(resubscribeGitStatusMock).toHaveBeenCalledWith("w1");
 
 		// cleanup returned by effect mock
 		const cleanup = useEffectMock.mock.results.at(-1)?.value as () => void;

--- a/apps/web/src/features/workspace/hooks/useGitStatus.ts
+++ b/apps/web/src/features/workspace/hooks/useGitStatus.ts
@@ -7,6 +7,7 @@ import {
 import {
 	onDaemonWsReconnect,
 	onGitStatusEvent,
+	resubscribeGitStatus,
 	subscribeGitStatus,
 	unsubscribeGitStatus,
 } from "../../../shared/lib/daemon/ws";
@@ -122,7 +123,7 @@ export function useGitStatus(workspaceId: string | null): GitStatusMap {
 		// Re-subscribe on WS reconnect
 		const offReconnect = onDaemonWsReconnect(() => {
 			if (id !== fetchIdRef.current) return;
-			subscribeGitStatus(workspaceId);
+			resubscribeGitStatus(workspaceId);
 		});
 
 		return () => {

--- a/apps/web/src/shared/stores/app-store.ts
+++ b/apps/web/src/shared/stores/app-store.ts
@@ -272,6 +272,10 @@ export interface AppState {
 	availableAgents: AvailableAgent[];
 	setAvailableAgents: (agents: AvailableAgent[]) => void;
 
+	// Agent launch overlay
+	agentLaunchOverlay: boolean;
+	setAgentLaunchOverlay: (v: boolean) => void;
+
 	// Editor
 	openFilePath: string | null;
 	openFileContent: string | null;
@@ -814,6 +818,9 @@ export const useAppStore = create<AppState>((set) => ({
 			sessionsByWorkspacePath: {},
 			activeSessionIdByWorkspacePath: {},
 		}),
+
+	agentLaunchOverlay: false,
+	setAgentLaunchOverlay: (v) => set({ agentLaunchOverlay: v }),
 
 	availableAgents: [],
 	setAvailableAgents: (agents) => set({ availableAgents: agents }),


### PR DESCRIPTION
## Summary
- Lift the "Getting things ready" loading overlay from Terminal to WorkspaceView so it persists across the InlineAgentPicker → Terminal component swap, eliminating visual flicker during agent launch
- Add `agentLaunchOverlay` state to the Zustand store, set before the REST call and cleared on first terminal output or error
- Auto-delete agent sessions when the terminal process exits (ctrl-c, agent finish, etc.) so stale stopped sessions no longer linger in the sidebar
- Stabilize macOS daemon startup (launchctl bootstrap idempotency) and agent runtime environment

## Test plan
- [x] All 336 existing tests pass (`npx vitest run`)
- [ ] Launch an agent → "Getting things ready" overlay appears instantly on click, no flicker, no blinking cursor visible
- [ ] Overlay persists until agent first output, then reveals terminal smoothly
- [ ] If launch fails (e.g. agent not found), overlay disappears and error shows
- [ ] Reconnecting to an existing terminal still shows an opaque loading overlay
- [ ] Exit agent via ctrl-c → session tab removed from sidebar, view returns to files panel
- [ ] Delete agent via sidebar context menu → session removed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)